### PR TITLE
Add Volume Adjuster

### DIFF
--- a/Boxify/App.xaml.cs
+++ b/Boxify/App.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation.Metadata;
@@ -36,7 +35,8 @@ namespace Boxify
             this.RequiresPointerMode = ApplicationRequiresPointerMode.WhenRequested;
 
             // Playback Service "Initialization" of static class
-            PlaybackService.queue.CurrentItemChanged += PlaybackService.songChanges;
+            PlaybackService.queue.CurrentItemChanged += PlaybackService.currentItemChanged;
+            PlaybackService.queue.ItemFailed += PlaybackService.itemFailed;
             PlaybackService.Player.PlaybackSession.PlaybackStateChanged += PlaybackService.playStateChanges;
 
             // Subscribe to key lifecyle events to know when the app
@@ -141,6 +141,34 @@ namespace Boxify
                 else
                 {
                     Settings.playbackSource = Playbacksource.Spotify;
+                }
+
+                // repeat
+                if (composite["RepeatEnabled"] != null && composite["RepeatEnabled"].ToString() == "True")
+                {
+                    Settings.repeatEnabled = true;
+                }
+                else
+                {
+                    Settings.repeatEnabled = false;
+                }
+
+                // volume
+                if (composite["Volume"] != null)
+                {
+                    double value;
+                    if (Double.TryParse(composite["Volume"].ToString(), out value))
+                    {
+                        Settings.volume = value;
+                    }
+                    else
+                    {
+                        Settings.volume = 100;
+                    }
+                }
+                else
+                {
+                    Settings.volume = 100;
                 }
             }
             else

--- a/Boxify/Classes/PlaybackService.cs
+++ b/Boxify/Classes/PlaybackService.cs
@@ -51,6 +51,7 @@ namespace Boxify
             queue.Items.Clear();
             Player.Source = queue;
             await currentSession.loadTracks(0, PlaybackSession.INITIAL_TRACKS_REQUEST);
+            mainPage.setPlaybackMenu(false);
         }
 
         /// <summary>
@@ -123,16 +124,6 @@ namespace Boxify
         }
 
         /// <summary>
-        /// Toggle shuffling of the playlist
-        /// </summary>
-        /// <returns></returns>
-        public static bool toggleShuffle()
-        {
-            queue.ShuffleEnabled = !queue.ShuffleEnabled;
-            return queue.ShuffleEnabled;
-        }
-
-        /// <summary>
         /// Toggle repeating of the playlist
         /// </summary>
         /// <returns></returns>
@@ -147,7 +138,7 @@ namespace Boxify
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        public static async void songChanges(object sender, CurrentMediaPlaybackItemChangedEventArgs e)
+        public static async void currentItemChanged(object sender, CurrentMediaPlaybackItemChangedEventArgs e)
         {
             currentlyPlayingItem = e.NewItem;
             if (e.NewItem != null)
@@ -158,7 +149,6 @@ namespace Boxify
                 {
                     if (!App.isInBackgroundMode)
                     {
-                        mainPage.setPlaybackMenu(false);
                         if (Player.SystemMediaTransportControls.DisplayUpdater.Thumbnail != null)
                         {
                             IRandomAccessStreamWithContentType thumbnail = await Player.SystemMediaTransportControls.DisplayUpdater.Thumbnail.OpenReadAsync();
@@ -167,10 +157,20 @@ namespace Boxify
                             mainPage.getPlaybackMenu().setTrackImage(bitmapImage);
                         }
                         mainPage.getPlaybackMenu().setTrackName(Player.SystemMediaTransportControls.DisplayUpdater.MusicProperties.Title);
-                        mainPage.getPlaybackMenu().setAlbumName(Player.SystemMediaTransportControls.DisplayUpdater.MusicProperties.AlbumTitle);
+                        mainPage.getPlaybackMenu().setArtistName(Player.SystemMediaTransportControls.DisplayUpdater.MusicProperties.Artist);
                     }
                 });
             }
+        }
+
+        /// <summary>
+        /// An item failed to open after download
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        public static void itemFailed(object sender, MediaPlaybackItemFailedEventArgs e)
+        {
+            currentSession.itemFailedToOpen(e.Item);
         }
 
         /// <summary>

--- a/Boxify/Controls/Playback.xaml
+++ b/Boxify/Controls/Playback.xaml
@@ -29,7 +29,7 @@
             <ProgressRing Name="LoadingTrack"
                           RelativePanel.AlignHorizontalCenterWithPanel="True"
                           RelativePanel.AlignTopWith="TrackName"
-                          RelativePanel.AlignBottomWith="TrackAlbum"
+                          RelativePanel.AlignBottomWith="TrackArtist"
                           Width="60"
                           Height="60"
                           Foreground="{ThemeResource SystemAccentColor}"
@@ -43,16 +43,16 @@
 
             <TextBlock Name="TrackName"
                        RelativePanel.RightOf="AlbumArt"
-                       RelativePanel.LeftOf="Shuffle"
+                       RelativePanel.LeftOf="Repeat"
                        RelativePanel.AlignTopWithPanel="True"
                        HorizontalAlignment="Stretch"
                        Text=""
                        Style="{StaticResource SubheaderTextBlockStyle}"
                        TextAlignment="Center" />
 
-            <TextBlock Name="TrackAlbum"
+            <TextBlock Name="TrackArtist"
                        RelativePanel.AlignLeftWith="TrackName"
-                       RelativePanel.LeftOf="Shuffle"
+                       RelativePanel.LeftOf="Repeat"
                        RelativePanel.Below="TrackName"
                        Text=""
                        Style="{StaticResource TitleTextBlockStyle}"
@@ -76,33 +76,15 @@
                          Background="{ThemeResource PlaybackProgressBackground}"/>
 
             <TextBlock Name="Duration"
-                       RelativePanel.LeftOf="Shuffle"
+                       RelativePanel.LeftOf="Repeat"
                        RelativePanel.AlignBottomWithPanel="True"
                        Margin="0,0,10,0"
                        Style="{StaticResource BodyTextBlockStyle}"
                        Text="00:00"/>
 
-            <Button Name="Shuffle"
-                    RelativePanel.LeftOf="Previous"
-                    RelativePanel.AlignBottomWithPanel="True"
-                    Margin="0,0,0,0"
-                    Style="{StaticResource PlaybackSmallButtonStyle}"
-                    Content="&#xE8B1;"
-                    Click="Shuffle_Click" />
-
-            <Button Name="ShuffleEnabled"
-                    RelativePanel.LeftOf="Previous"
-                    RelativePanel.AlignBottomWithPanel="True"
-                    Margin="0,0,0,0"
-                    Style="{StaticResource PlaybackSmallButtonStyle}"
-                    Foreground="Green"
-                    Visibility="Collapsed"
-                    Content="&#xE8B1;"
-                    Click="Shuffle_Click" />
-
             <Button Name="Repeat"
                     RelativePanel.LeftOf="Previous"
-                    RelativePanel.Above="Shuffle"
+                    RelativePanel.AlignBottomWithPanel="True"
                     Margin="0,0,0,0"
                     Style="{StaticResource PlaybackSmallButtonStyle}"
                     Content="&#xE8EE;"
@@ -110,13 +92,35 @@
 
             <Button Name="RepeatEnabled"
                     RelativePanel.LeftOf="Previous"
-                    RelativePanel.Above="Shuffle"
+                    RelativePanel.AlignBottomWithPanel="True"
                     Margin="0,0,0,0"
                     Style="{StaticResource PlaybackSmallButtonStyle}"
                     Foreground="Green"
                     Visibility="Collapsed"
                     Content="&#xE8EE;"
                     Click="Repeat_Click" />
+
+            <Button Name="Volume"
+                    RelativePanel.LeftOf="Previous"
+                    RelativePanel.Above="Repeat"
+                    Margin="0,0,0,0"
+                    Style="{StaticResource PlaybackSmallButtonStyle}"
+                    Content="&#xE767;"
+                    Click="Volume_Click"/>
+
+            <Slider Name="VolumeSlider"
+                    Visibility="Collapsed"
+                    RelativePanel.Above="Volume"
+                    RelativePanel.LeftOf="Previous"
+                    RelativePanel.AlignBottomWithPanel="True"
+                    RelativePanel.AlignTopWithPanel="True"
+                    Margin="1,10,0,10"
+                    Orientation="Vertical"
+                    TickPlacement="None"
+                    SmallChange="10"
+                    LostFocus="VolumeSlider_LostFocus"
+                    ValueChanged="VolumeSlider_ValueChanged"/>
+
 
             <Button Name="Play"
                     RelativePanel.AlignRightWithPanel="True"

--- a/Boxify/Frames/MainPage.xaml
+++ b/Boxify/Frames/MainPage.xaml
@@ -96,11 +96,12 @@
                        Canvas.ZIndex="1"/>
 
             <TextBlock Name="UserName"
-                       RelativePanel.LeftOf="UserPicContainer" 
+                       RelativePanel.LeftOf="UserPicContainer"
+                       RelativePanel.RightOf="SpotifyLoading"
                        Margin="0,25,10,0"
-                       Width="Auto"
                        Text="User Name"
                        Style="{StaticResource TitleTextBlockStyle}"
+                       TextAlignment="Right"
                        PointerReleased="userElement_PointerReleased"/>
 
             <Ellipse Name="UserPicContainer"

--- a/Boxify/Frames/MainPage.xaml.cs
+++ b/Boxify/Frames/MainPage.xaml.cs
@@ -133,6 +133,10 @@ namespace Boxify
                 {
                     MainContentFrame.Margin = new Thickness(0, 0, 0, 100);
                 }
+
+                PlaybackMenu.setRepeat(Settings.repeatEnabled);
+                PlaybackMenu.setVolume(Settings.volume);
+
                 PlaybackMenu.Visibility = Visibility.Visible;
             });
         }
@@ -398,6 +402,11 @@ namespace Boxify
             {
                 MainContentFrame.Focus(FocusState.Programmatic);
             }
+            else if (e.Key == VirtualKey.Escape && ((Slider)e.OriginalSource).Name == "VolumeSlider")
+            {
+                PlaybackMenu.VolumeSlider_LostFocus(null, null);
+                PlaybackMenu.FocusOnVolume();
+            }
         }
 
         /// <summary>
@@ -428,6 +437,7 @@ namespace Boxify
             YouTubeMessage.Visibility = Visibility.Collapsed;
             SpotifyLogo.Visibility = Visibility.Visible;
             SpotifyLoading.Visibility = Visibility.Visible;
+            UserName.SetValue(RelativePanel.RightOfProperty, SpotifyLoading);
         }
 
         /// <summary>
@@ -501,6 +511,7 @@ namespace Boxify
                     YouTubeMessage.Visibility = Visibility.Visible;
                     YouTubeMessage.Text = "";
                 }
+                UserName.SetValue(RelativePanel.RightOfProperty, YouTubeLoading);
             }
         }
 

--- a/Boxify/Frames/Settings.xaml.cs
+++ b/Boxify/Frames/Settings.xaml.cs
@@ -19,9 +19,12 @@ namespace Boxify
         public enum Playbacksource { Spotify, YouTube }
 
         private static MainPage mainPage;
+
         public static bool tvSafeArea = true;
         public static Theme theme = Theme.System;
         public static Playbacksource playbackSource = Playbacksource.Spotify;
+        public static bool repeatEnabled = false;
+        public static double volume = 100;
 
         /// <summary>
         /// Main constructor
@@ -153,14 +156,16 @@ namespace Boxify
         /// <summary>
         /// Set the roaming settings for the application
         /// </summary>
-        private void saveSettings()
+        public static void saveSettings()
         {
             ApplicationDataContainer roamingSettings = ApplicationData.Current.RoamingSettings;
 
             ApplicationDataCompositeValue composite = new ApplicationDataCompositeValue();
-            composite["TvSafeAreaOff"] = !TvSafeArea.IsOn;
+            composite["TvSafeAreaOff"] = !tvSafeArea;
             composite["Theme"] = theme.ToString();
             composite["PlaybackSource"] = playbackSource.ToString();
+            composite["RepeatEnabled"] = repeatEnabled.ToString();
+            composite["Volume"] = volume.ToString();
 
             roamingSettings.Values["UserSettings"] = composite;
         }

--- a/Boxify/Frames/YourMusic.xaml.cs
+++ b/Boxify/Frames/YourMusic.xaml.cs
@@ -66,6 +66,7 @@ namespace Boxify
                             mainPage.setSpotifyLoadingValue(playlistsSave.Count);
                             await Task.Delay(TimeSpan.FromMilliseconds(100));
                         }
+                        mainPage.setSpotifyLoadingValue(playlistsCount);
                     }
                     foreach (PlaylistList playlist in playlistsSave)
                     {


### PR DESCRIPTION
Allow user to adjust playback volume. Remeber repeat and volume. Display Artist name instead of Album name in stationary playback viewer. Ensure browse load bar reaches completion on Your Playlists. Remove grey-out on playback buttons while track loading. Catch if track fails to open. Ellipse long user names.