### PR TITLE
Do Not Nullify Controls on Background Switch

### DIFF
--- a/Boxify/Classes/Album.cs
+++ b/Boxify/Classes/Album.cs
@@ -186,20 +186,15 @@ namespace Boxify
             disposed = true;
             if (disposing)
             {
-                id = null;
-                name = null;
                 while (artists.Count > 0)
                 {
                     Artist artist = artists.ElementAt(0);
                     artists.Remove(artist);
                     artist.Dispose();
-                    artist = null;
                 }
                 artists.Clear();
-                artists = null;
-                image.UriSource = null;
-                image = null;
-                imageUrl = null;
+
+                image.ClearValue(BitmapImage.UriSourceProperty);
             }
         }
     }

--- a/Boxify/Classes/Artist.cs
+++ b/Boxify/Classes/Artist.cs
@@ -65,7 +65,7 @@ namespace Boxify
             disposed = true;
             if (disposing)
             {
-               name = null;
+               
             }
         }
     }

--- a/Boxify/Classes/PlaybackService.cs
+++ b/Boxify/Classes/PlaybackService.cs
@@ -118,7 +118,6 @@ namespace Boxify.Classes
             {
                 MediaPlaybackItem item = queue.Items.First(kvp => kvp.Source.CustomProperties["mediaItemId"].ToString() == mediaId);
                 queue.Items.Remove(item);
-                item = null;
             }
         }
 

--- a/Boxify/Classes/PlaybackSession.cs
+++ b/Boxify/Classes/PlaybackSession.cs
@@ -989,13 +989,10 @@ namespace Boxify.Classes
             if (!disposing)
             {
                 playlistMediaIds.Clear();
-                playlistMediaIds = null;
 
                 prevRemoteAttempts.Clear();
-                prevRemoteAttempts = null;
 
                 nextRemoteAttempts.Clear();
-                nextRemoteAttempts = null;
             }
         }
     }

--- a/Boxify/Classes/Playlist.cs
+++ b/Boxify/Classes/Playlist.cs
@@ -131,13 +131,7 @@ namespace Boxify
             disposed = true;
             if (disposing)
             {
-                id = null;
-                href = null;
-                name = null;
-                description = null;
-                tracksHref = null;
-                image.UriSource = null;
-                image = null;
+                image.ClearValue(BitmapImage.UriSourceProperty);
             }
         }
     }

--- a/Boxify/Classes/Track.cs
+++ b/Boxify/Classes/Track.cs
@@ -162,24 +162,15 @@ namespace Boxify
             disposed = true;
             if (disposing)
             {
-                id = null;
-                href = null;
-                name = null;
-                albumJson = null;
-                previewUrl = null;
 
                 album.Dispose();
-                album = null;
                 while (artists.Count > 0)
                 {
                     Artist artist = artists.ElementAt(0);
                     artists.Remove(artist);
                     artist.Dispose();
-                    artist = null;
                 }
                 artists.Clear();
-                artists = null;
-                previewUrl = null;
             }
         }
     }

--- a/Boxify/Controls/AlbumList.xaml.cs
+++ b/Boxify/Controls/AlbumList.xaml.cs
@@ -70,13 +70,8 @@ namespace Boxify.Controls
             await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 album.Dispose();
-                album = null;
 
-                Image.Source = null;
-                Image = null;
-                DisplayName = null;
-                ArtistLabel = null;
-                Artist = null;
+                Image.ClearValue(Image.SourceProperty);
             });
         }
     }

--- a/Boxify/Controls/Announcements/PlaybackMode.xaml.cs
+++ b/Boxify/Controls/Announcements/PlaybackMode.xaml.cs
@@ -94,25 +94,12 @@ namespace Boxify.Controls.Announcements
         /// <param name="e"></param>
         public async void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            if (MainPage.closedAnnouncements || App.isInBackgroundMode)
+            if (MainPage.closedAnnouncements || (App.isInBackgroundMode && MainPage.closedAnnouncements))
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (Spotify != null)
-                    {
-                        Spotify.Click -= PlaybackMode_Click;
-                        Spotify = null;
-                    }
-                    if (YouTube != null)
-                    {
-                        YouTube.Click -= PlaybackMode_Click;
-                        YouTube = null;
-                    }
-
-                    Header = null;
-                    Message = null;
-
-                    CenteredPanel = null;
+                    Spotify.Click -= PlaybackMode_Click;
+                    YouTube.Click -= PlaybackMode_Click;
                 });
             }
         }

--- a/Boxify/Controls/Announcements/PlaybackOptions.xaml.cs
+++ b/Boxify/Controls/Announcements/PlaybackOptions.xaml.cs
@@ -90,29 +90,12 @@ namespace Boxify.Controls.Announcements
         /// <param name="e"></param>
         public async void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            if (MainPage.closedAnnouncements || App.isInBackgroundMode)
+            if (MainPage.closedAnnouncements || (App.isInBackgroundMode && MainPage.closedAnnouncements))
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (RepeatSwitch != null)
-                    {
-                        RepeatSwitch.Toggled -= RepeatSwitch_Toggled;
-                        RepeatSwitch = null;
-                    }
-                    if (ShuffleSwitch != null)
-                    {
-                        ShuffleSwitch.Toggled -= ShuffleSwitch_Toggled;
-                        ShuffleSwitch = null;
-                    }
-
-                    RepeatLabel = null;
-                    ShuffleLabel = null;
-                    ToggleGrid = null;
-
-                    Message = null;
-                    Header = null;
-
-                    CenteredPanel = null;
+                    RepeatSwitch.Toggled -= RepeatSwitch_Toggled;
+                    ShuffleSwitch.Toggled -= ShuffleSwitch_Toggled;
                 });
             }
         }

--- a/Boxify/Controls/Announcements/Shuffle.xaml.cs
+++ b/Boxify/Controls/Announcements/Shuffle.xaml.cs
@@ -87,22 +87,11 @@ namespace Boxify.Controls.Announcements
         /// <param name="e"></param>
         public async void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            if (MainPage.closedAnnouncements || App.isInBackgroundMode)
+            if (MainPage.closedAnnouncements || (App.isInBackgroundMode && MainPage.closedAnnouncements))
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (ShuffleSwitch != null)
-                    {
-                        ShuffleSwitch.Toggled -= ShuffleSwitch_Toggled;
-                        ShuffleSwitch = null;
-                    }
-
-                    ShuffleIcon = null;
-                    Message = null;
-                    Header = null;
-                    Version = null;
-
-                    CenteredPanel = null;
+                    ShuffleSwitch.Toggled -= ShuffleSwitch_Toggled;
                 });
             }
         }

--- a/Boxify/Controls/Announcements/ThemeMode.xaml.cs
+++ b/Boxify/Controls/Announcements/ThemeMode.xaml.cs
@@ -121,30 +121,13 @@ namespace Boxify.Controls.Announcements
         /// <param name="e"></param>
         public async void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            if (MainPage.closedAnnouncements || App.isInBackgroundMode)
+            if (MainPage.closedAnnouncements || (App.isInBackgroundMode && MainPage.closedAnnouncements))
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (System != null)
-                    {
-                        System.Click -= ThemeMode_Click;
-                        System = null;
-                    }
-                    if (Light != null)
-                    {
-                        Light.Click -= ThemeMode_Click;
-                        Light = null;
-                    }
-                    if (Dark != null)
-                    {
-                        Dark.Click -= ThemeMode_Click;
-                        Dark = null;
-                    }
-
-                    Header = null;
-                    Message = null;
-
-                    CenteredPanel = null;
+                    System.Click -= ThemeMode_Click;
+                    Light.Click -= ThemeMode_Click;
+                    Dark.Click -= ThemeMode_Click;
                 });
             }
         }

--- a/Boxify/Controls/Announcements/TvMode.xaml.cs
+++ b/Boxify/Controls/Announcements/TvMode.xaml.cs
@@ -81,20 +81,11 @@ namespace Boxify.Controls.Announcements
         /// <param name="e"></param>
         public async void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            if (MainPage.closedAnnouncements || App.isInBackgroundMode)
+            if (MainPage.closedAnnouncements || (App.isInBackgroundMode && MainPage.closedAnnouncements))
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (TvModeSwitch != null)
-                    {
-                        TvModeSwitch.Toggled -= TvModeSwitch_Toggled;
-                        TvModeSwitch = null;
-                    }
-
-                    Header = null;
-                    Message = null;
-
-                    CenteredPanel = null;
+                    TvModeSwitch.Toggled -= TvModeSwitch_Toggled;
                 });
             }
         }

--- a/Boxify/Controls/Announcements/Welcome.xaml.cs
+++ b/Boxify/Controls/Announcements/Welcome.xaml.cs
@@ -65,25 +65,12 @@ namespace Boxify.Controls.Announcements
         /// <param name="e"></param>
         public async void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            if (MainPage.closedAnnouncements || App.isInBackgroundMode)
+            if (MainPage.closedAnnouncements || (App.isInBackgroundMode && MainPage.closedAnnouncements))
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (Close != null)
-                    {
-                        Close.Click -= Close_Click;
-                        Close = null;
-                    }
-                    if (Settings != null)
-                    {
-                        Settings.Click -= Settings_Click;
-                        Settings = null;
-                    }
-
-                    Header = null;
-                    Message = null;
-
-                    CenteredPanel = null;
+                    Close.Click -= Close_Click;
+                    Settings.Click -= Settings_Click;
                 });
             }
         }

--- a/Boxify/Controls/CancelDialog.xaml.cs
+++ b/Boxify/Controls/CancelDialog.xaml.cs
@@ -73,13 +73,7 @@ namespace Boxify.Controls
         {
             await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                if (Cancel != null)
-                {
-                    Cancel.Click -= Cancel_Click;
-                    Cancel = null;
-                }
-
-                CancelText = null;
+                Cancel.Click -= Cancel_Click;
             });
         }
     }

--- a/Boxify/Controls/Playback.xaml.cs
+++ b/Boxify/Controls/Playback.xaml.cs
@@ -533,65 +533,16 @@ namespace Boxify.Controls
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (uiUpdateTimer != null)
-                    {
-                        uiUpdateTimer.Tick -= UiUpdateTimer_Tick;
-                        uiUpdateTimer = null;
-                    }
-
-                    if (Repeat != null)
-                    {
-                        Repeat.Click -= Repeat_Click;
-                        Repeat = null;
-                    }
-                    if (RepeatEnabled != null)
-                    {
-                        RepeatEnabled.Click -= Repeat_Click;
-                        RepeatEnabled = null;
-                    }
-                    if (Volume != null)
-                    {
-                        Volume.Click -= Volume_Click;
-                        Volume = null;
-                    }
-                    if (VolumeSlider != null)
-                    {
-                        VolumeSlider.LostFocus -= VolumeSlider_LostFocus;
-                        VolumeSlider.ValueChanged -= VolumeSlider_ValueChanged;
-                        VolumeSlider = null;
-                    }
-                    if (Play != null)
-                    {
-                        Play.Click -= PlayPause_Click;
-                        Play = null;
-                    }
-                    if (Pause != null)
-                    {
-                        Pause.Click -= PlayPause_Click;
-                        Pause = null;
-                    }
-                    if (Previous != null)
-                    {
-                        Previous.Click -= Previous_Click;
-                        Previous = null;
-                    }
-                    if (Next != null)
-                    {
-                        Next.Click -= Next_Click;
-                        Next = null;
-                    }
-
-                    LoadingTrack = null;
-                    AlbumArt.Source = null;
-                    AlbumArt = null;
-                    TrackName = null;
-                    TrackArtist = null;
-                    CurrentTime = null;
-                    Progress = null;
-                    Duration = null;
-
-                    MainPanel = null;
-                    MainGrid = null;
+                    uiUpdateTimer.Tick -= UiUpdateTimer_Tick;
+                    Repeat.Click -= Repeat_Click;
+                    RepeatEnabled.Click -= Repeat_Click;
+                    Volume.Click -= Volume_Click;
+                    VolumeSlider.LostFocus -= VolumeSlider_LostFocus;
+                    VolumeSlider.ValueChanged -= VolumeSlider_ValueChanged;
+                    Play.Click -= PlayPause_Click;
+                    Pause.Click -= PlayPause_Click;
+                    Previous.Click -= Previous_Click;
+                    Next.Click -= Next_Click;
                 });
             }
         }

--- a/Boxify/Controls/PlaylistHero.xaml.cs
+++ b/Boxify/Controls/PlaylistHero.xaml.cs
@@ -63,14 +63,8 @@ namespace Boxify.Controls
         public void Unload()
         {
             playlist.Dispose();
-            playlist = null;
 
-            Image.Source = null;
-            Image = null;
-            DisplayName = null;
-            Description = null;
-            TracksLabel = null;
-            Tracks = null;
+            Image.ClearValue(Image.SourceProperty);
         }
     }
 }

--- a/Boxify/Controls/PlaylistList.xaml.cs
+++ b/Boxify/Controls/PlaylistList.xaml.cs
@@ -65,13 +65,8 @@ namespace Boxify.Controls
         public void Unload()
         {
             playlist.Dispose();
-            playlist = null;
 
-            Image.Source = null;
-            Image = null;
-            DisplayName = null;
-            Tracks = null;
-            TracksLabel = null;
+            Image.ClearValue(Image.SourceProperty);
         }
     }
 }

--- a/Boxify/Controls/TrackList.xaml.cs
+++ b/Boxify/Controls/TrackList.xaml.cs
@@ -65,13 +65,8 @@ namespace Boxify.Controls
         public void Unload()
         {
             track.Dispose();
-            track = null;
 
-            Image.Source = null;
-            Image = null;
-            DisplayName = null;
-            ArtistLabel = null;
-            Artist = null;
+            Image.ClearValue(Image.SourceProperty);
         }
     }
 }

--- a/Boxify/Frames/Browse.xaml.cs
+++ b/Boxify/Frames/Browse.xaml.cs
@@ -147,7 +147,6 @@ namespace Boxify.Frames
                 PlaylistHero playlistHero = FeaturedPlaylists.Items.ElementAt(0) as PlaylistHero;
                 playlistHero.Unload();
                 FeaturedPlaylists.Items.Remove(playlistHero);
-                playlistHero = null;
             }
             await LoadFeaturedPlaylists();
         }
@@ -187,37 +186,19 @@ namespace Boxify.Frames
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
                     Bindings.StopTracking();
-                    if (FeaturedPlaylists != null)
+
+                    FeaturedPlaylists.ItemClick -= FeaturedPlaylists_ItemClick;
+                    FeaturedPlaylists.ClearValue(XYFocusUpProperty);
+
+                    while (FeaturedPlaylists.Items.Count > 0)
                     {
-                        FeaturedPlaylists.ItemClick -= FeaturedPlaylists_ItemClick;
-                        FeaturedPlaylists.ClearValue(XYFocusUpProperty);
-
-                        while (FeaturedPlaylists.Items.Count > 0)
-                        {
-                            PlaylistHero playlistHero = FeaturedPlaylists.Items.ElementAt(0) as PlaylistHero;
-                            FeaturedPlaylists.Items.Remove(playlistHero);
-                            playlistHero.Unload();
-                            playlistHero = null;
-                        }
-
-                        FeaturedPlaylists.ItemsSource = null;
-                        FeaturedPlaylists = null;
+                        PlaylistHero playlistHero = FeaturedPlaylists.Items.ElementAt(0) as PlaylistHero;
+                        FeaturedPlaylists.Items.Remove(playlistHero);
+                        playlistHero.Unload();
                     }
 
-                    if (Refresh != null)
-                    {
-                        Refresh.Click -= Refresh_Click;
-                        Refresh.ClearValue(XYFocusRightProperty);
-                        Refresh = null;
-                    }
-                    if (More != null)
-                    {
-                        More.Click -= More_Click;
-                        More = null;
-                    }
-
-                    FeaturedPlaylistLabel = null;
-                    FeaturedPlaylistMessage = null;
+                    Refresh.Click -= Refresh_Click;
+                    More.Click -= More_Click;
                 });
             }
         }

--- a/Boxify/Frames/MainPage.xaml.cs
+++ b/Boxify/Frames/MainPage.xaml.cs
@@ -927,7 +927,6 @@ namespace Boxify.Frames
                     announcementItems.Remove(welcome);
                     welcome.UserControl_Unloaded(null, null);
                     welcome.Unloaded -= welcome.UserControl_Unloaded;
-                    welcome = null;
                 }
                 if (announcement is PlaybackMode)
                 {
@@ -935,7 +934,6 @@ namespace Boxify.Frames
                     announcementItems.Remove(playbackMode);
                     playbackMode.UserControl_Unloaded(null, null);
                     playbackMode.Unloaded -= playbackMode.UserControl_Unloaded;
-                    playbackMode = null;
                 }
                 if (announcement is ThemeMode)
                 {
@@ -943,7 +941,6 @@ namespace Boxify.Frames
                     announcementItems.Remove(themeMode);
                     themeMode.UserControl_Unloaded(null, null);
                     themeMode.Unloaded -= themeMode.UserControl_Unloaded;
-                    themeMode = null;
                 }
                 if (announcement is TvMode)
                 {
@@ -951,7 +948,6 @@ namespace Boxify.Frames
                     announcementItems.Remove(tvMode);
                     tvMode.UserControl_Unloaded(null, null);
                     tvMode.Unloaded -= tvMode.UserControl_Unloaded;
-                    tvMode = null;
                 }
                 if (announcement is PlaybackOptions)
                 {
@@ -959,7 +955,6 @@ namespace Boxify.Frames
                     announcementItems.Remove(playbackOptions);
                     playbackOptions.UserControl_Unloaded(null, null);
                     playbackOptions.Unloaded -= playbackOptions.UserControl_Unloaded;
-                    playbackOptions = null;
                 }
                 if (announcement is Shuffle)
                 {
@@ -967,7 +962,6 @@ namespace Boxify.Frames
                     announcementItems.Remove(shuffle);
                     shuffle.UserControl_Unloaded(null, null);
                     shuffle.Unloaded -= shuffle.UserControl_Unloaded;
-                    shuffle = null;
                 }
             }
         }
@@ -988,188 +982,69 @@ namespace Boxify.Frames
                     currentNavSelection = null;
 
                     // direct elements
-                    if (UserName != null)
-                    {
-                        UserName.PointerReleased -= UserElement_PointerReleased;
-                        UserName = null;
-                    }
-                    if (UserPicContainer != null)
-                    {
-                        UserPicContainer.PointerReleased -= UserElement_PointerReleased;
-                        UserPicContainer = null;
-                    }
-                    if (BlankUser != null)
-                    {
-                        BlankUser.PointerReleased -= UserElement_PointerReleased;
-                        BlankUser = null;
-                    }
-                    if (Hamburger != null)
-                    {
-                        Hamburger.Click -= Hamburger_Click;
-                        Hamburger = null;
-                    }
-                    if (Back != null)
-                    {
-                        Back.Click -= Back_Click;
-                        Back = null;
-                    }
-                    Title = null;
-                    SpotifyLogo = null;
-                    SpotifyLoading = null;
-                    YouTubeLogo = null;
-                    YouTubeLoading = null;
-                    LoadersMessage = null;
-                    Header = null;
-                    NavLeftBorder = null;
-                    NavLeftBorderHamburgerExtension = null;
-                    RightMainBackground = null;
-                    UserPic = null;
+                    UserName.PointerReleased -= UserElement_PointerReleased;
+                    UserPicContainer.PointerReleased -= UserElement_PointerReleased;
+                    BlankUser.PointerReleased -= UserElement_PointerReleased;
+                    Hamburger.Click -= Hamburger_Click;
+                    Back.Click -= Back_Click;
+                    HamburgerOptions.SelectionChanged -= HamburgerOptions_SelectionChanged;
+                    SettingsItem.Click -= SettingsItem_Click;
 
-                    if (HamburgerOptions != null)
-                    {
-                        HamburgerOptions.SelectionChanged -= HamburgerOptions_SelectionChanged;
-                        HamburgerOptions = null;
-                    }
-                    if (SettingsItem != null)
-                    {
-                        SettingsItem.Click -= SettingsItem_Click;
-                        SettingsItem = null;
-                    }
-
-                    BrowseItem = null;
-                    BrowseItemHighlight = null;
-                    BrowseItemIcon = null;
-                    YourMusicItem = null;
-                    YourMusicItemHighlight = null;
-                    YourMusicItemIcon = null;
-                    ProfileItem = null;
-                    ProfileItemHighlight = null;
-                    ProfileItemIcon = null;
-                    SearchItem = null;
-                    SearchItemHighlight = null;
-                    SearchItemIcon = null;
-
-                    if (CancelDialog != null)
-                    {
-                        CancelDialog.Unload();
-                        CancelDialog = null;
-                    }
-                    ErrorMessage = null;
-                    ErrorMessageGrid = null;
-
-                    MainContentFrame = null;
-                    MainSplitView = null;
-
-                    if (PlaybackMenu != null)
-                    {
-                        PlaybackMenu.UserControl_Unloaded(null, null);
-                        PlaybackMenu.Unloaded -= PlaybackMenu.UserControl_Unloaded;
-                        PlaybackMenu = null;
-                    }
+                    CancelDialog.Unload();
+                    PlaybackMenu.UserControl_Unloaded(null, null);
+                    PlaybackMenu.Unloaded -= PlaybackMenu.UserControl_Unloaded;
 
                     // dependant pages
-                    if (browsePage != null)
+                    await Task.Run(() =>
                     {
-                        await Task.Run(() =>
-                        {
-                            if (browsePage != null)
-                            {
-                                browsePage.Page_Unloaded(null, null);
-                            }
-                        });
                         if (browsePage != null)
                         {
-                            browsePage.Unloaded -= browsePage.Page_Unloaded;
-                            browsePage.NavigationCacheMode = NavigationCacheMode.Disabled;
-                            browsePage = null;
+                            browsePage.Page_Unloaded(null, null);
                         }
+                        if (profilePage != null)
+                        {
+                            profilePage.Page_Unloaded(null, null);
+                        }
+                        if (yourMusicPage != null)
+                        {
+                            yourMusicPage.Page_Unloaded(null, null);
+                        }
+                        if (searchPage != null)
+                        {
+                            searchPage.Page_Unloaded(null, null);
+                        }
+                        if (settingsPage != null)
+                        {
+                            settingsPage.Page_Unloaded(null, null);
+                        }                        
+                    });
+                    if (browsePage != null)
+                    {
+                        browsePage.Unloaded -= browsePage.Page_Unloaded;
                     }
                     if (profilePage != null)
                     {
-                        await Task.Run(() =>
-                        {
-                            if (profilePage != null)
-                            {
-                                profilePage.Page_Unloaded(null, null);
-                            }
-                        });
-                        if (profilePage != null)
-                        {
-                            profilePage.Unloaded -= profilePage.Page_Unloaded;
-                            profilePage.NavigationCacheMode = NavigationCacheMode.Disabled;
-                            profilePage = null;
-                        }
+                        profilePage.Unloaded -= profilePage.Page_Unloaded;
                     }
                     if (yourMusicPage != null)
                     {
-                        await Task.Run(() =>
-                        {
-                            if (yourMusicPage != null)
-                            {
-                                yourMusicPage.Page_Unloaded(null, null);
-                            }
-                        });
-                        if (yourMusicPage != null)
-                        {
-                            yourMusicPage.Unloaded -= yourMusicPage.Page_Unloaded;
-                            yourMusicPage.NavigationCacheMode = NavigationCacheMode.Disabled;
-                            yourMusicPage = null;
-                        }
+                        yourMusicPage.Unloaded -= yourMusicPage.Page_Unloaded;
                     }
                     if (searchPage != null)
                     {
-                        await Task.Run(() =>
-                        {
-                            if (searchPage != null)
-                            {
-                                searchPage.Page_Unloaded(null, null);
-                            }
-                        });
-                        if (searchPage != null)
-                        {
-                            searchPage.Unloaded -= searchPage.Page_Unloaded;
-                            searchPage.NavigationCacheMode = NavigationCacheMode.Disabled;
-                            searchPage = null;
-                        }
+                        searchPage.Unloaded -= searchPage.Page_Unloaded;
                     }
                     if (settingsPage != null)
                     {
-                        await Task.Run(() => settingsPage.Page_Unloaded(null, null));
-                        if (settingsPage != null)
-                        {
-                            settingsPage.Unloaded -= settingsPage.Page_Unloaded;
-                            settingsPage.NavigationCacheMode = NavigationCacheMode.Disabled;
-                            settingsPage = null;
-                        }
+                        settingsPage.Unloaded -= settingsPage.Page_Unloaded;
                     }
 
                     // announcements
-                    UnloadAnnouncements();
-                    Announcements = null;
-                    AnnouncementsBackground = null;
-
-                    if (PreviousAnnouncement != null)
-                    {
-                        PreviousAnnouncement.Click -= PreviousAnnouncement_Click;
-                        PreviousAnnouncement = null;
-                    }
-                    if (NextAnnouncement != null)
-                    {
-                        NextAnnouncement.Click -= NextAnnouncement_Click;
-                        NextAnnouncement = null;
-                    }
-                    if (CloseAnnouncements != null)
-                    {
-                        CloseAnnouncements.Click -= CloseAnnouncements_Click;
-                        CloseAnnouncements = null;
-                    }
-                    if (AnnouncementsContainer != null)
-                    {
-                        AnnouncementsContainer.KeyUp -= AnnouncementsContainer_KeyUp;
-                        AnnouncementsContainer = null;
-                    }
-
-                    BackgroundGrid = null;
+                    Announcements.Content = null;
+                    PreviousAnnouncement.Click -= PreviousAnnouncement_Click;
+                    NextAnnouncement.Click -= NextAnnouncement_Click;
+                    CloseAnnouncements.Click -= CloseAnnouncements_Click;
+                    AnnouncementsContainer.KeyUp -= AnnouncementsContainer_KeyUp;
                 });
             }
         }

--- a/Boxify/Frames/Profile.xaml.cs
+++ b/Boxify/Frames/Profile.xaml.cs
@@ -164,21 +164,8 @@ namespace Boxify.Frames
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (WebBrowser != null)
-                    {
-                        WebBrowser.NavigationStarting -= WebView_NavigationStarting;
-                        WebBrowser = null;
-                    }
-                    if (Login != null)
-                    {
-                        Login.Click -= Login_Click;
-                        Login = null;
-                    }
-
-                    UserPic = null;
-                    UserPicContainer = null;
-                    BlankUser = null;
-                    Status = null;
+                    WebBrowser.NavigationStarting -= WebView_NavigationStarting;
+                    Login.Click -= Login_Click;
                 });
             }
         }

--- a/Boxify/Frames/Search.xaml.cs
+++ b/Boxify/Frames/Search.xaml.cs
@@ -253,6 +253,19 @@ namespace Boxify.Frames
         }
 
         /// <summary>
+        /// user hits enter to search
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void SearchBox_KeyUp(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Key == Windows.System.VirtualKey.Enter)
+            {
+                SearchButton_Click(null, null);
+            }
+        }
+
+        /// <summary>
         /// Clears the search results objects to purge them from memory
         /// </summary>
         private void ClearResults()
@@ -265,35 +278,19 @@ namespace Boxify.Frames
                     PlaylistList playlistList = listItem as PlaylistList;
                     playlistList.Unload();
                     Results.Items.Remove(playlistList);
-                    playlistList = null;
                 }
                 else if (listItem is TrackList)
                 {
                     TrackList trackList = listItem as TrackList;
                     trackList.Unload();
                     Results.Items.Remove(trackList);
-                    trackList = null;
                 }
                 else if (listItem is AlbumList)
                 {
                     AlbumList albumList = listItem as AlbumList;
                     albumList.Unload();
                     Results.Items.Remove(albumList);
-                    albumList = null;
                 }
-            }
-        }
-
-        /// <summary>
-        /// user hits enter to search
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void SearchBox_KeyUp(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
-        {
-            if (e.Key == Windows.System.VirtualKey.Enter)
-            {
-                SearchButton_Click(null, null);
             }
         }
 
@@ -308,25 +305,11 @@ namespace Boxify.Frames
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (Results != null)
-                    {
-                        Results.ItemClick -= Results_ItemClick;
-                        ClearResults();
-                        Results = null;
-                    }
-                    if (SearchType != null)
-                    {
-                        SearchType.SelectionChanged -= SearchButton_Click;
-                        SearchType = null;
-                    }
-                    if (SearchButton != null)
-                    {
-                        SearchButton.Click -= SearchButton_Click;
-                        SearchButton = null;
-                    }
+                    Results.ItemClick -= Results_ItemClick;
+                    ClearResults();
 
-                    SearchBox = null;
-                    Feedback = null;
+                    SearchType.SelectionChanged -= SearchButton_Click;
+                    SearchButton.Click -= SearchButton_Click;
                 });
             }
         }

--- a/Boxify/Frames/Settings.xaml.cs
+++ b/Boxify/Frames/Settings.xaml.cs
@@ -460,61 +460,17 @@ namespace Boxify.Frames
             {
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    if (TvSafeArea != null)
-                    {
-                        TvSafeArea.Toggled -= TvSafe_Toggled;
-                        TvSafeArea = null;
-                    }
-                    if (System != null)
-                    {
-                        System.Click -= ThemeColor_Click;
-                        System = null;
-                    }
-                    if (Light != null)
-                    {
-                        Light.Click -= ThemeColor_Click;
-                        Light = null;
-                    }
-                    if (Dark != null)
-                    {
-                        Dark.Click -= ThemeColor_Click;
-                        Dark = null;
-                    }
-                    if (Spotify != null)
-                    {
-                        Spotify.Click -= Playbacksource_Click;
-                        Spotify = null;
-                    }
-                    if (YouTube != null)
-                    {
-                        YouTube.Click -= Playbacksource_Click;
-                        YouTube = null;
-                    }
-                    if (WelcomeConfigure != null)
-                    {
-                        WelcomeConfigure.Click -= WelcomeConfigure_Click;
-                        WelcomeConfigure = null;
-                    }
-                    if (Shuffle != null)
-                    {
-                        Shuffle.Click -= Shuffle_Click;
-                        Shuffle = null;
-                    }
-                    if (RateButton != null)
-                    {
-                        RateButton.Click -= Rate_Click; SpotifyGitHub.Click -= SpotifyGitHub_Click;
-                        RateButton = null;
-                    }
-                    if (Repo != null)
-                    {
-                        Repo.Click -= Repo_Click;
-                        Repo = null;
-                    }
-                    if (PrivacyButton != null)
-                    {
-                        PrivacyButton.Click -= PrivacyButton_Click;
-                        PrivacyButton = null;
-                    }
+                    TvSafeArea.Toggled -= TvSafe_Toggled;
+                    System.Click -= ThemeColor_Click;
+                    Light.Click -= ThemeColor_Click;
+                    Dark.Click -= ThemeColor_Click;
+                    Spotify.Click -= Playbacksource_Click;
+                    YouTube.Click -= Playbacksource_Click;
+                    WelcomeConfigure.Click -= WelcomeConfigure_Click;
+                    Shuffle.Click -= Shuffle_Click;
+                    RateButton.Click -= Rate_Click; SpotifyGitHub.Click -= SpotifyGitHub_Click;
+                    Repo.Click -= Repo_Click;
+                    PrivacyButton.Click -= PrivacyButton_Click;
                 });
             }
         }

--- a/Boxify/Frames/YourMusic.xaml.cs
+++ b/Boxify/Frames/YourMusic.xaml.cs
@@ -233,7 +233,6 @@ namespace Boxify.Frames
                 PlaylistList playlistList = Playlists.Items.ElementAt(0) as PlaylistList;
                 playlistList.Unload();
                 Playlists.Items.Remove(playlistList);
-                playlistList = null;
             }
         }
 
@@ -294,41 +293,19 @@ namespace Boxify.Frames
                 {
                     Bindings.StopTracking();
 
-                    if (Playlists != null)
-                    {
-                        Playlists.ItemClick -= Playlists_ItemClick;
-                        clearPlaylists();
-                        Playlists = null;
-                    }
+                    Playlists.ItemClick -= Playlists_ItemClick;
+                    clearPlaylists();
 
-                    if (LogIn != null)
-                    {
-                        LogIn.Click -= LogIn_Click;
-                        LogIn = null;
-                    }
-                    if (Refresh != null)
-                    {
-                        Refresh.Click -= Refresh_Click;
-                        Refresh = null;
-                    }
-                    if (More != null)
-                    {
-                        More.Click -= More_Click;
-                        More = null;
-                    }
-                    if (preEmptiveLoadPlaylists != null)
-                    {
-                        while (preEmptiveLoadPlaylists.Count > 0)
-                        {
-                            PlaylistList playlistList = preEmptiveLoadPlaylists.ElementAt(0) as PlaylistList;
-                            playlistList.Unload();
-                            preEmptiveLoadPlaylists.Remove(playlistList);
-                            playlistList = null;
-                        }
-                    }
+                    LogIn.Click -= LogIn_Click;
+                    Refresh.Click -= Refresh_Click;
+                    More.Click -= More_Click;
 
-                    Warning = null;
-                    PlaylistsLabel = null;
+                    while (preEmptiveLoadPlaylists.Count > 0)
+                    {
+                        PlaylistList playlistList = preEmptiveLoadPlaylists.ElementAt(0) as PlaylistList;
+                        playlistList.Unload();
+                        preEmptiveLoadPlaylists.Remove(playlistList);
+                    }
                 });
             }
         }


### PR DESCRIPTION
No longer set controls to null when switch to background. This prevents NullPointerExceptions when switching betweeen background and foreground quickly, and doesn't seem to impact memory leaking too much.