### PR TITLE
Loading UI Locks

### DIFF
--- a/Boxify/App.xaml.cs
+++ b/Boxify/App.xaml.cs
@@ -159,11 +159,11 @@ namespace Boxify
                 // playback source
                 if (composite["PlaybackSource"] != null && composite["PlaybackSource"].ToString() == "YouTube")
                 {
-                    Settings.playbackSource = Settings.Playbacksource.YouTube;
+                    Settings.playbackSource = Settings.PlaybackSource.YouTube;
                 }
                 else
                 {
-                    Settings.playbackSource = Settings.Playbacksource.Spotify;
+                    Settings.playbackSource = Settings.PlaybackSource.Spotify;
                 }
 
                 // repeat
@@ -204,7 +204,7 @@ namespace Boxify
                 // Defaults
                 Settings.tvSafeArea = true;
                 Settings.theme = Settings.Theme.System;
-                Settings.playbackSource = Settings.Playbacksource.Spotify;
+                Settings.playbackSource = Settings.PlaybackSource.Spotify;
                 Settings.repeatEnabled = false;
                 Settings.shuffleEnabled = false;
                 Settings.volume = 100;

--- a/Boxify/Classes/PlaybackSession.cs
+++ b/Boxify/Classes/PlaybackSession.cs
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.If not, see<http://www.gnu.org/licenses/>.
 *******************************************************************/
 
+using Boxify.Frames;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -46,7 +47,7 @@ namespace Boxify.Classes
         private static Random rng = new Random();
 
         public long localLock;
-        private Playbacksource source = Playbacksource.Spotify;
+        private PlaybackSource source = PlaybackSource.Spotify;
         public PlaybackType type;
         private bool shuffling;
         public string tracksHref;
@@ -74,7 +75,7 @@ namespace Boxify.Classes
         /// <param name="shuffle">Whether or not shuffling is enabled for session playback</param>
         /// <param name="tracksHref">The reference to the download location for tracks</param>
         /// <param name="totalTracks">The total number of tracks in the playback session</param>
-        public PlaybackSession(long currentLock, Playbacksource source, PlaybackType type, bool shuffle, string tracksHref, int totalTracks)
+        public PlaybackSession(long currentLock, PlaybackSource source, PlaybackType type, bool shuffle, string tracksHref, int totalTracks)
         {
             localLock = currentLock;
             this.source = source;
@@ -85,7 +86,10 @@ namespace Boxify.Classes
             prevRemoteAttempts.Add(0);
             if (App.mainPage != null)
             {
-                App.mainPage.SetLoadersMessage("", localLock);
+                long loadingKey = DateTime.Now.Ticks;
+                MainPage.AddLoadingLock(loadingKey);
+                App.mainPage.SetLoadersMessage("", localLock, loadingKey);
+                MainPage.RemoveLoadingLock(loadingKey);
             }
         }
 
@@ -93,10 +97,10 @@ namespace Boxify.Classes
         /// Update the UI with the current number of tracks that have failed
         /// </summary>
         /// <param name="increment"></param>
-        private void UpdateFailuresCount(int increment)
+        private void UpdateFailuresCount(int increment, long loadingKey)
         {
             failuresCount += increment;
-            App.mainPage.SetLoadersMessage(failuresCount + " track" + (failuresCount == 1 ? "" : "s") + " failed to match", localLock);
+            App.mainPage.SetLoadersMessage(failuresCount + " track" + (failuresCount == 1 ? "" : "s") + " failed to match", localLock, loadingKey);
         }
 
         /// <summary>
@@ -119,6 +123,8 @@ namespace Boxify.Classes
         /// <returns>True a total of end - start tracks are downloaded, false otherwise</returns>
         public async Task<bool> LoadTracks(int start, int end, bool lockOverride)
         {
+            long loadingKey = DateTime.Now.Ticks;
+            MainPage.AddLoadingLock(loadingKey);
             if (loadLock && !lockOverride)
             {
                 return false;
@@ -161,17 +167,7 @@ namespace Boxify.Classes
                 limit = end - start + 1;
             }
 
-            if (source == Playbacksource.Spotify)
-            {
-                App.mainPage.SetSpotifyLoadingMaximum(limit, localLock);
-                App.mainPage.SetSpotifyLoadingValue(0, localLock);
-                App.mainPage.BringUpSpotify(localLock);
-            }
-            else if (source == Playbacksource.YouTube)
-            {
-                App.mainPage.SetYouTubeValues(0, limit, localLock);
-                App.mainPage.BringUpYouTube(localLock);
-            }
+            App.mainPage.SetLoadingProgress(source, 0, limit, localLock, loadingKey);
 
             if (localLock != App.playbackService.GlobalLock) { return false; }
 
@@ -189,24 +185,17 @@ namespace Boxify.Classes
             if (tracks.Count == totalTracks)
             {
                 limit = totalTracks;
-                if (source == Playbacksource.Spotify)
-                {
-                    App.mainPage.SetSpotifyLoadingMaximum(limit, localLock);
-                }
-                else if (source == Playbacksource.YouTube)
-                {
-                    App.mainPage.SetYouTubeValues(0, limit, localLock);
-                }
+                App.mainPage.SetLoadingProgress(source, 0, limit, localLock, loadingKey);
             }
 
             if (tracks.Count != limit)
             {
-                UpdateFailuresCount(limit - tracks.Count);
+                UpdateFailuresCount(limit - tracks.Count, loadingKey);
             }
 
             List<KeyValuePair<MediaSource, Track>> sources = new List<KeyValuePair<MediaSource, Track>>();
 
-            if (source == Playbacksource.Spotify)
+            if (source == PlaybackSource.Spotify)
             {
                 for (int i = 0; i < tracks.Count; i++)
                 {
@@ -219,13 +208,13 @@ namespace Boxify.Classes
                         }
                         else
                         {
-                            UpdateFailuresCount(1);
+                            UpdateFailuresCount(1, loadingKey);
                         }
                     }
-                    App.mainPage.SetSpotifyLoadingValue(i + 1 + limit - tracks.Count, localLock);
+                    App.mainPage.SetLoadingProgress(source, i + 1 + limit - tracks.Count, limit, localLock, loadingKey);
                 }
             }
-            else if (source == Playbacksource.YouTube && localLock == App.playbackService.GlobalLock)
+            else if (source == PlaybackSource.YouTube && localLock == App.playbackService.GlobalLock)
             {
                 for (int i = 0; i < tracks.Count; i++)
                 {
@@ -241,7 +230,7 @@ namespace Boxify.Classes
                     {
                         if (videoId == "")
                         {
-                            UpdateFailuresCount(1);
+                            UpdateFailuresCount(1, loadingKey);
                         }
                         else
                         {
@@ -251,11 +240,11 @@ namespace Boxify.Classes
                             }
                             catch (Exception)
                             {
-                                UpdateFailuresCount(1);
+                                UpdateFailuresCount(1, loadingKey);
                             }
                         }
                     }
-                    App.mainPage.SetYouTubeValues(i + 1 + limit - tracks.Count, limit, localLock);
+                    App.mainPage.SetLoadingProgress(PlaybackSource.YouTube, i + 1 + limit - tracks.Count, limit, localLock, loadingKey);
                 }
             }
 
@@ -300,6 +289,8 @@ namespace Boxify.Classes
                 App.playbackService.PlayFromBeginning(localLock);
             }
 
+            MainPage.RemoveLoadingLock(loadingKey);
+
             if (shuffling)
             {
                 if (successes != limit && shufflePositionsAvailable.Count > 0)
@@ -339,6 +330,8 @@ namespace Boxify.Classes
         /// <returns>True a total of end - start tracks are downloaded, false otherwise</returns>
         public async Task<bool> LoadTracksReverse(int start, int end, bool lockOverride)
         {
+            long loadingKey = DateTime.Now.Ticks;
+            MainPage.AddLoadingLock(loadingKey);
             if (loadLock && !lockOverride)
             {
                 return false;
@@ -355,30 +348,20 @@ namespace Boxify.Classes
 
             int limit = end - start + 1;
 
-            if (this.source == Playbacksource.Spotify)
-            {
-                App.mainPage.SetSpotifyLoadingMaximum(limit, localLock);
-                App.mainPage.SetSpotifyLoadingValue(0, localLock);
-                App.mainPage.BringUpSpotify(localLock);
-            }
-            else if (this.source == Playbacksource.YouTube)
-            {
-                App.mainPage.SetYouTubeValues(0, limit, localLock);
-                App.mainPage.BringUpYouTube(localLock);
-            }
+            App.mainPage.SetLoadingProgress(source, 0, limit, localLock, loadingKey);
 
             if (localLock != App.playbackService.GlobalLock) { return false; }
 
             List<Track> tracks = await GetTracksInRange(start, limit);
             if (tracks.Count != limit)
             {
-                UpdateFailuresCount(limit - tracks.Count);
+                UpdateFailuresCount(limit - tracks.Count, loadingKey);
             }
             else
             {
                 List<KeyValuePair<MediaSource, Track>> sources = new List<KeyValuePair<MediaSource, Track>>();
 
-                if (this.source == Playbacksource.Spotify)
+                if (this.source == PlaybackSource.Spotify)
                 {
                     for (int i = 0; i < tracks.Count; i++)
                     {
@@ -391,13 +374,13 @@ namespace Boxify.Classes
                             }
                             else
                             {
-                                UpdateFailuresCount(1);
+                                UpdateFailuresCount(1, loadingKey);
                             }
                         }
-                        App.mainPage.SetSpotifyLoadingValue(i + 1 + limit - tracks.Count, localLock);
+                        App.mainPage.SetLoadingProgress(source, i + 1 + limit - tracks.Count, limit, localLock, loadingKey);
                     }
                 }
-                else if (this.source == Playbacksource.YouTube && localLock == App.playbackService.GlobalLock)
+                else if (this.source == PlaybackSource.YouTube && localLock == App.playbackService.GlobalLock)
                 {
                     for (int i = 0; i < tracks.Count; i++)
                     {
@@ -413,7 +396,7 @@ namespace Boxify.Classes
                         {
                             if (videoId == "")
                             {
-                                UpdateFailuresCount(1);
+                                UpdateFailuresCount(1, loadingKey);
                             }
                             else
                             {
@@ -423,11 +406,11 @@ namespace Boxify.Classes
                                 }
                                 catch (Exception)
                                 {
-                                    UpdateFailuresCount(1);
+                                    UpdateFailuresCount(1, loadingKey);
                                 }
                             }
                         }
-                        App.mainPage.SetYouTubeValues(i + 1 + limit - tracks.Count, limit, localLock);
+                        App.mainPage.SetLoadingProgress(PlaybackSource.YouTube, i + 1 + limit - tracks.Count, limit, localLock, loadingKey);
                     }
                 }
 
@@ -459,6 +442,8 @@ namespace Boxify.Classes
                     }
                 }
             }
+
+            MainPage.RemoveLoadingLock(loadingKey);
 
             if (successes != limit && start > 0)
             {
@@ -665,7 +650,10 @@ namespace Boxify.Classes
         {
             App.playbackService.RemoveFromQueue(GetMediaItemId(item), localLock);
             playlistMediaIds.RemoveAt(playlistMediaIds.IndexOf(GetMediaItemId(item)));
-            UpdateFailuresCount(1);
+            long loadingKey = DateTime.Now.Ticks;
+            MainPage.AddLoadingLock(loadingKey);
+            UpdateFailuresCount(1, loadingKey);
+            MainPage.RemoveLoadingLock(loadingKey);
         }
 
         /// <summary>

--- a/Boxify/Controls/Announcements/PlaybackMode.xaml.cs
+++ b/Boxify/Controls/Announcements/PlaybackMode.xaml.cs
@@ -45,15 +45,15 @@ namespace Boxify.Controls.Announcements
         /// Construct the object with a pre-defined source
         /// </summary>
         /// <param name="source">The current source of the app</param>
-        public PlaybackMode(Playbacksource source) : this()
+        public PlaybackMode(PlaybackSource source) : this()
         {
             YouTube.Click -= PlaybackMode_Click;
             Spotify.Click -= PlaybackMode_Click;
-            if (source == Playbacksource.Spotify)
+            if (source == PlaybackSource.Spotify)
             {
                 Spotify.IsChecked = true;
             }
-            else if (source == Playbacksource.YouTube)
+            else if (source == PlaybackSource.YouTube)
             {
                 YouTube.IsChecked = true;
             }
@@ -68,14 +68,14 @@ namespace Boxify.Controls.Announcements
         /// <param name="e"></param>
         private void PlaybackMode_Click(object sender, RoutedEventArgs e)
         {
-            Playbacksource source = Playbacksource.Spotify;
+            PlaybackSource source = PlaybackSource.Spotify;
             if (Spotify.IsChecked == true)
             {
-                source = Playbacksource.Spotify;
+                source = PlaybackSource.Spotify;
             }
             else if (YouTube.IsChecked == true)
             {
-                source = Playbacksource.YouTube;
+                source = PlaybackSource.YouTube;
             }
             if (MainPage.settingsPage != null)
             {

--- a/Boxify/Frames/Search.xaml.cs
+++ b/Boxify/Frames/Search.xaml.cs
@@ -27,6 +27,7 @@ using Windows.Data.Json;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using static Boxify.Frames.Settings;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -120,9 +121,9 @@ namespace Boxify.Frames
                             }
                             else
                             {
-                                App.mainPage.SetSpotifyLoadingMaximum(playlistsArray.Count);
-                                App.mainPage.SetSpotifyLoadingValue(0);
-                                App.mainPage.BringUpSpotify();
+                                long loadingKey = DateTime.Now.Ticks;
+                                MainPage.AddLoadingLock(loadingKey);
+                                App.mainPage.SetLoadingProgress(PlaybackSource.Spotify, 0, playlistsArray.Count, loadingKey);
                                 foreach (JsonValue playlistJson in playlistsArray)
                                 {
 
@@ -137,8 +138,9 @@ namespace Boxify.Frames
                                         }
                                     }
                                     catch (COMException) { }
-                                    App.mainPage.SetSpotifyLoadingValue(Results.Items.Count);
+                                    App.mainPage.SetLoadingProgress(PlaybackSource.Spotify, Results.Items.Count, playlistsArray.Count, loadingKey);
                                 }
+                                MainPage.RemoveLoadingLock(loadingKey);
                             }
                         }
                     }
@@ -159,9 +161,9 @@ namespace Boxify.Frames
                             }
                             else
                             {
-                                App.mainPage.SetSpotifyLoadingMaximum(tracksArray.Count);
-                                App.mainPage.SetSpotifyLoadingValue(0);
-                                App.mainPage.BringUpSpotify();
+                                long loadingKey = DateTime.Now.Ticks;
+                                MainPage.AddLoadingLock(loadingKey);
+                                App.mainPage.SetLoadingProgress(PlaybackSource.Spotify, 0, tracksArray.Count, loadingKey);
                                 foreach (JsonValue trackJson in tracksArray)
                                 {
                                     Track track = new Track();
@@ -175,8 +177,9 @@ namespace Boxify.Frames
                                         }
                                     }
                                     catch (COMException) { }
-                                    App.mainPage.SetSpotifyLoadingValue(Results.Items.Count);
+                                    App.mainPage.SetLoadingProgress(PlaybackSource.Spotify, Results.Items.Count, tracksArray.Count, loadingKey);
                                 }
+                                MainPage.RemoveLoadingLock(loadingKey);
                             }
                         }
                     }
@@ -197,9 +200,9 @@ namespace Boxify.Frames
                             }
                             else
                             {
-                                App.mainPage.SetSpotifyLoadingMaximum(albumsArray.Count);
-                                App.mainPage.SetSpotifyLoadingValue(0);
-                                App.mainPage.BringUpSpotify();
+                                long loadingKey = DateTime.Now.Ticks;
+                                MainPage.AddLoadingLock(loadingKey);
+                                App.mainPage.SetLoadingProgress(PlaybackSource.Spotify, 0, albumsArray.Count, loadingKey);
                                 foreach (JsonValue albumJson in albumsArray)
                                 {
                                     Album album = new Album();
@@ -213,8 +216,9 @@ namespace Boxify.Frames
                                         }
                                     }
                                     catch (COMException) { }
-                                    App.mainPage.SetSpotifyLoadingValue(Results.Items.Count);
+                                    App.mainPage.SetLoadingProgress(PlaybackSource.Spotify, Results.Items.Count, albumsArray.Count, loadingKey);
                                 }
+                                MainPage.RemoveLoadingLock(loadingKey);
                             }
                         }
                     }

--- a/Boxify/Frames/Settings.xaml.cs
+++ b/Boxify/Frames/Settings.xaml.cs
@@ -37,11 +37,11 @@ namespace Boxify.Frames
     public sealed partial class Settings : Page
     {
         public enum Theme { System, Light, Dark }
-        public enum Playbacksource { Spotify, YouTube }
+        public enum PlaybackSource { Spotify, YouTube }
 
         public static bool tvSafeArea = true;
         public static Theme theme = Theme.System;
-        public static Playbacksource playbackSource = Playbacksource.Spotify;
+        public static PlaybackSource playbackSource = PlaybackSource.Spotify;
         public static bool repeatEnabled = false;
         public static bool shuffleEnabled = false;
         public static double volume = 100;
@@ -73,7 +73,7 @@ namespace Boxify.Frames
             }
 
             // playback source
-            if (playbackSource == Playbacksource.YouTube)
+            if (playbackSource == PlaybackSource.YouTube)
             {
                 YouTube.IsChecked = true;
             }
@@ -234,11 +234,11 @@ namespace Boxify.Frames
         {
             if (((RadioButton)sender).Name == "Spotify")
             {
-                playbackSource = Playbacksource.Spotify;
+                playbackSource = PlaybackSource.Spotify;
             }
             else if (((RadioButton)sender).Name == "YouTube")
             {
-                playbackSource = Playbacksource.YouTube;
+                playbackSource = PlaybackSource.YouTube;
             }
             SaveSettings();
         }
@@ -247,14 +247,14 @@ namespace Boxify.Frames
         /// Change the playback type and update the UI
         /// </summary>
         /// <param name="source">The source to get tracks from</param>
-        public void SetPlaybackSourceUI(Playbacksource source)
+        public void SetPlaybackSourceUI(PlaybackSource source)
         {
             SetPlaybackSource(source);
-            if (source == Playbacksource.Spotify)
+            if (source == PlaybackSource.Spotify)
             {
                 Spotify.IsChecked = true;
             }
-            else if (source == Playbacksource.YouTube)
+            else if (source == PlaybackSource.YouTube)
             {
                 YouTube.IsChecked = true;
             }
@@ -264,7 +264,7 @@ namespace Boxify.Frames
         /// Change the playback type
         /// </summary>
         /// <param name="source"></param>
-        public static void SetPlaybackSource(Playbacksource source)
+        public static void SetPlaybackSource(PlaybackSource source)
         {
             playbackSource = source;
             SaveSettings();


### PR DESCRIPTION
Ensure the latest loading operation has precedence on the UI to prevent interwoven updates for disparate loading operations.